### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # da-ayr-design-documentation
-AYR's design decisions and related documentation
+
+# The National Archives: Access Your Records (AYR) Technical Alpha
+AYR's design decisions and related documentation for the Technical Alpha December 2022-March 2023
+
+## Background
+This is the central repository for the Access Your Records Service.
+The other repositories are 
+* [The Authentication Server](https://github.com/nationalarchives/da-ayr-auth-server)
+* [Front End Code](https://github.com/nationalarchives/da-ayr-webapp) 
+
+Information from the Discovery and Alpha (user journey and wireframes) are found on the [Google Drive](https://drive.google.com/drive/u/2/folders/1ESA6VcOhyZZu1ZijnH2_0-5jgLsWl9-a) (no public access)
+
+## Common Acronyms used:
+### Services directly related to this one:
+* AYR - Access Your Records, a service that aims to provide government users with access to (closed) digital records they have transfered to TNA (The National Arcivhes) via TDR (Transfer Digital Records)
+* TDR - [Transfer Digital Records](https://github.com/nationalarchives/tdr-dev-documentation)
+* TRE - [Transformation Engine](https://github.com/nationalarchives/da-transform-dev-documentation/blob/develop/editorial-system-integration/README.md)
+
+### Outside the scope of this alpha:
+* DRI - [Preservation](https://github.com/nationalarchives/dri-automation)
+* TNA - The National Archives of the Government of the UK
+* [Discovery](https://discovery.nationalarchives.gov.uk/) - Catalog of records held by TNA
+* FOI - Freedom of Information request
+
+## The Team
+* Nicki Welch, Service Owner for Access to Digital Records
+* George Doji, Product Owner for Access Your Records (AYR)
+* Heather Lindon, Delivery Manager Access to Digital Records Team
+* Matt Arnold, Technical Architect for Digital Archiving Department at TNA 


### PR DESCRIPTION
Added acronym glossary and team information for the project after discussion at Retro on 7 December. Need to check it's ok to put our team member names down here as it is a public repo? Or perhaps it would be better in a Wiki, although I don't see the option to create a wiki on my view of the repo.